### PR TITLE
Fix error TypeError in validationFailMsg

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -52,7 +52,7 @@ Object.assign(Block.prototype, SimpleBlock.fn, require('./block-validations'), {
   icon_name: 'default',
 
   validationFailMsg: function() {
-    return i18n.t('errors:validation_fail', { type: this.title });
+    return i18n.t('errors:validation_fail', { type: _.isFunction(this.title) ? this.title() : this.title });
   },
 
   editorHTML: '<div class="st-block__editor"></div>',


### PR DESCRIPTION
Hi!

If `this.title` is not function then method `validationFailMsg` throws exception:

```
TypeError: this.title is not a function(…)
```

If this error occurs on `on_post` form's event - browser reloaded and data magically way didn't saved.
